### PR TITLE
Feature/[IndexView]修复reload清空选中数据

### DIFF
--- a/packages/meta-components/src/components/index-view/hooks/useTable.ts
+++ b/packages/meta-components/src/components/index-view/hooks/useTable.ts
@@ -94,7 +94,7 @@ function useAntdTable<R = any, Item = any, U extends Item = any>(
   const { run } = result
 
   const reload = useCallback(() => {
-    run(pageable, params, true)
+    run(pageable, params, 'reload')
   }, [pageable, params])
 
   useEffect(() => {

--- a/packages/meta-components/src/components/index-view/hooks/useTable.ts
+++ b/packages/meta-components/src/components/index-view/hooks/useTable.ts
@@ -94,7 +94,7 @@ function useAntdTable<R = any, Item = any, U extends Item = any>(
   const { run } = result
 
   const reload = useCallback(() => {
-    run(pageable, params)
+    run(pageable, params, true)
   }, [pageable, params])
 
   useEffect(() => {

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -1,8 +1,8 @@
 ## IndexView
 
-#### 基本用法
+<!-- #### 基本用法 -->
 
-```tsx
+<!-- ```tsx
 import React, { useCallback, useMemo, useRef } from 'react'
 import {
   IndexView,
@@ -236,7 +236,7 @@ export default () => {
     </>
   )
 }
-```
+``` -->
 
 #### 开启多选
 
@@ -419,9 +419,12 @@ export default () => {
 
   const items = [
     {
-      text: '按钮1',
+      text: '刷新',
       type: 'primary',
-      callback: () => message.success('按钮1被点了'),
+      callback: () => {
+        console.log('按钮1被点了', ref)
+        ref.current.reload()
+      },
     },
     {
       text: '打印选择行',
@@ -468,6 +471,7 @@ export default () => {
       defaultSelectionType="checkbox"
       tableOperate={tableOperate}
       logicFilter
+      overPageSelect
       // urlQuery
     >
       <ToolBar>
@@ -481,7 +485,7 @@ export default () => {
 }
 ```
 
-#### 搜素字段自定义
+<!-- #### 搜素字段自定义
 
 ```tsx
 import React, { useMemo } from 'react'
@@ -957,4 +961,4 @@ export default () => {
     </IndexView>
   )
 }
-```
+``` -->

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -471,7 +471,7 @@ export default () => {
       defaultSelectionType="checkbox"
       tableOperate={tableOperate}
       logicFilter
-      overPageSelect
+      selectedOption={{ keepSelected: false, overPage: true }}
       // keepReloadSelect
       // urlQuery
     >
@@ -714,7 +714,7 @@ export default () => {
       loadData={loadData}
       defaultSelectionType="checkbox"
       pagination={{ simple: true }}
-      overPageSelect
+      selectedOption={{ keepSelected: true, overPage: true }}
       urlQuery
     >
       <FilterPanel

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -394,12 +394,19 @@ const visibleColumns = [
     visiable: true,
   },
 ]
+const makeData = (current) => {
+  return data.map((row) => ({
+    ...row,
+    id: `${current}-${row.id}`,
+    name: `${current}-${row.name}`,
+  }))
+}
 
 export default () => {
   const ref = useRef()
   const loadData = (pageable, filterParams) => {
     const result = {
-      list: data,
+      list: makeData(pageable?.current || 1),
       total: 20,
       current: pageable?.current || 1,
       pageSize: pageable?.pageSize || 10,
@@ -471,7 +478,7 @@ export default () => {
       defaultSelectionType="checkbox"
       tableOperate={tableOperate}
       logicFilter
-      selectedOption={{ keepSelected: false, overPage: true }}
+      selectedOption={['overPage', 'keepSelected']}
       // keepReloadSelect
       // urlQuery
     >
@@ -714,7 +721,7 @@ export default () => {
       loadData={loadData}
       defaultSelectionType="checkbox"
       pagination={{ simple: true }}
-      selectedOption={{ keepSelected: true, overPage: true }}
+      selectedOption={['overPage']}
       urlQuery
     >
       <FilterPanel
@@ -899,7 +906,6 @@ export default () => {
       pageSize: number
     }>(function (resolve) {
       setTimeout(function () {
-        console.log('promiseResult')
         resolve(result)
       }, 1000)
     })

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -1,8 +1,8 @@
 ## IndexView
 
-<!-- #### 基本用法 -->
+#### 基本用法
 
-<!-- ```tsx
+```tsx
 import React, { useCallback, useMemo, useRef } from 'react'
 import {
   IndexView,
@@ -236,7 +236,7 @@ export default () => {
     </>
   )
 }
-``` -->
+```
 
 #### 开启多选
 
@@ -485,7 +485,7 @@ export default () => {
 }
 ```
 
-<!-- #### 搜素字段自定义
+#### 搜素字段自定义
 
 ```tsx
 import React, { useMemo } from 'react'
@@ -961,4 +961,4 @@ export default () => {
     </IndexView>
   )
 }
-``` -->
+```

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -478,7 +478,7 @@ export default () => {
       defaultSelectionType="checkbox"
       tableOperate={tableOperate}
       logicFilter
-      selectedOption={['overPage', 'keepSelected']}
+      selectedClear={['overPage', 'keepSelected']}
       // keepReloadSelect
       // urlQuery
     >
@@ -721,7 +721,7 @@ export default () => {
       loadData={loadData}
       defaultSelectionType="checkbox"
       pagination={{ simple: true }}
-      selectedOption={['overPage']}
+      selectedClear={['overPage']}
       urlQuery
     >
       <FilterPanel

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -472,6 +472,7 @@ export default () => {
       tableOperate={tableOperate}
       logicFilter
       overPageSelect
+      // keepReloadSelect
       // urlQuery
     >
       <ToolBar>

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -103,6 +103,10 @@ export interface IIndexViewProps<IParams = any> {
    * @description 当翻页时保留已选择的记录
    */
   overPageSelect?: boolean
+  /**
+   * @description 执行reload时保留已选择的记录
+   */
+  keepReloadSelect?: boolean
 }
 
 export declare type IndexViewRefType = {
@@ -133,10 +137,14 @@ export const IndexView = React.forwardRef(
       urlQuery,
       tableOption,
       overPageSelect,
+      keepReloadSelect,
       children,
     }: IIndexViewProps & { children: React.ReactNode },
     ref: React.MutableRefObject<IndexViewRefType>
   ) => {
+    IndexView.defaultProps = {
+      keepReloadSelect: false,
+    }
     const [query, setQuery] = useQuery()
     const preParamsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
     const paramsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
@@ -232,12 +240,12 @@ export const IndexView = React.forwardRef(
       [preParamsRef, setPreParams]
     )
 
-    const onloadData = (pageable, params, reload?: Boolean) => {
+    const onloadData = (pageable, params, mode?: 'reload' | 'normal') => {
       return loadData(
         pageable,
         logicFilter ? params : simpleParams(params)
       ).then((data) => {
-        if (!overPageSelect || reload) {
+        if ((!overPageSelect || mode === 'reload') && !keepReloadSelect) {
           setSelectedRowKeys([])
           setSelectedRows([])
         }

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -232,12 +232,12 @@ export const IndexView = React.forwardRef(
       [preParamsRef, setPreParams]
     )
 
-    const onloadData = (pageable, params) => {
+    const onloadData = (pageable, params, reload?: Boolean) => {
       return loadData(
         pageable,
         logicFilter ? params : simpleParams(params)
       ).then((data) => {
-        if (!overPageSelect) {
+        if (!overPageSelect || reload) {
           setSelectedRowKeys([])
           setSelectedRows([])
         }

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -107,7 +107,7 @@ export interface IIndexViewProps<IParams = any> {
    * @description 当翻页时保留已选择的记录
    */
   overPageSelect?: boolean
-  selectedOption?: SelectedOption
+  selectedOption?: ('overPage' | 'keepSelected')[]
 }
 
 export declare type IndexViewRefType = {
@@ -144,7 +144,7 @@ export const IndexView = React.forwardRef(
     ref: React.MutableRefObject<IndexViewRefType>
   ) => {
     IndexView.defaultProps = {
-      selectedOption: { keepSelected: false, overPage: false },
+      selectedOption: [],
     }
     const [query, setQuery] = useQuery()
     const preParamsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
@@ -241,12 +241,14 @@ export const IndexView = React.forwardRef(
       [preParamsRef, setPreParams]
     )
     const onloadData = (pageable, params, mode?: 'reload' | 'normal') => {
-      const { keepSelected, overPage } = selectedOption
       return loadData(
         pageable,
         logicFilter ? params : simpleParams(params)
       ).then((data) => {
-        if (!overPage || (mode === 'reload' && !keepSelected)) {
+        if (
+          selectedOption?.indexOf('overPage') === -1 ||
+          (mode === 'reload' && selectedOption?.indexOf('keepSelected') === -1)
+        ) {
           setSelectedRowKeys([])
           setSelectedRows([])
         }
@@ -348,7 +350,7 @@ export const IndexView = React.forwardRef(
               type: selectionType,
               selectedRowKeys,
               onChange: (keys: string[], rows: RowData[]) => {
-                if (selectedOption.overPage) {
+                if (selectedOption?.indexOf('overPage') !== -1) {
                   setSelectedRowKeys(
                     selectedRowKeys
                       .filter(

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -107,10 +107,6 @@ export interface IIndexViewProps<IParams = any> {
    * @description 当翻页时保留已选择的记录
    */
   overPageSelect?: boolean
-  /**
-   * @description 执行reload时保留已选择的记录
-   */
-  keepReloadSelect?: boolean
   selectedOption?: SelectedOption
 }
 
@@ -142,7 +138,6 @@ export const IndexView = React.forwardRef(
       urlQuery,
       tableOption,
       overPageSelect,
-      keepReloadSelect,
       selectedOption,
       children,
     }: IIndexViewProps & { children: React.ReactNode },

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -59,6 +59,10 @@ type TableOption = Pick<
   | 'rowClassName'
   | 'size'
 >
+interface SelectedOption {
+  keepSelected?: boolean
+  overPage?: boolean
+}
 
 export interface IIndexViewProps<IParams = any> {
   /**
@@ -107,6 +111,7 @@ export interface IIndexViewProps<IParams = any> {
    * @description 执行reload时保留已选择的记录
    */
   keepReloadSelect?: boolean
+  selectedOption?: SelectedOption
 }
 
 export declare type IndexViewRefType = {
@@ -138,12 +143,13 @@ export const IndexView = React.forwardRef(
       tableOption,
       overPageSelect,
       keepReloadSelect,
+      selectedOption,
       children,
     }: IIndexViewProps & { children: React.ReactNode },
     ref: React.MutableRefObject<IndexViewRefType>
   ) => {
     IndexView.defaultProps = {
-      keepReloadSelect: false,
+      selectedOption: { keepSelected: false, overPage: false },
     }
     const [query, setQuery] = useQuery()
     const preParamsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
@@ -239,13 +245,13 @@ export const IndexView = React.forwardRef(
       }),
       [preParamsRef, setPreParams]
     )
-
     const onloadData = (pageable, params, mode?: 'reload' | 'normal') => {
+      const { keepSelected, overPage } = selectedOption
       return loadData(
         pageable,
         logicFilter ? params : simpleParams(params)
       ).then((data) => {
-        if ((!overPageSelect || mode === 'reload') && !keepReloadSelect) {
+        if (!overPage || (mode === 'reload' && !keepSelected)) {
           setSelectedRowKeys([])
           setSelectedRows([])
         }
@@ -347,7 +353,7 @@ export const IndexView = React.forwardRef(
               type: selectionType,
               selectedRowKeys,
               onChange: (keys: string[], rows: RowData[]) => {
-                if (overPageSelect) {
+                if (selectedOption.overPage) {
                   setSelectedRowKeys(
                     selectedRowKeys
                       .filter(

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -107,7 +107,7 @@ export interface IIndexViewProps<IParams = any> {
    * @description 当翻页时保留已选择的记录
    */
   overPageSelect?: boolean
-  selectedOption?: ('overPage' | 'keepSelected')[]
+  selectedClear?: ('overPage' | 'keepSelected')[]
 }
 
 export declare type IndexViewRefType = {
@@ -138,13 +138,13 @@ export const IndexView = React.forwardRef(
       urlQuery,
       tableOption,
       overPageSelect,
-      selectedOption,
+      selectedClear,
       children,
     }: IIndexViewProps & { children: React.ReactNode },
     ref: React.MutableRefObject<IndexViewRefType>
   ) => {
     IndexView.defaultProps = {
-      selectedOption: [],
+      selectedClear: [],
     }
     const [query, setQuery] = useQuery()
     const preParamsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
@@ -246,8 +246,8 @@ export const IndexView = React.forwardRef(
         logicFilter ? params : simpleParams(params)
       ).then((data) => {
         if (
-          selectedOption?.indexOf('overPage') === -1 ||
-          (mode === 'reload' && selectedOption?.indexOf('keepSelected') === -1)
+          selectedClear?.indexOf('overPage') === -1 ||
+          (mode === 'reload' && selectedClear?.indexOf('keepSelected') === -1)
         ) {
           setSelectedRowKeys([])
           setSelectedRows([])
@@ -350,7 +350,7 @@ export const IndexView = React.forwardRef(
               type: selectionType,
               selectedRowKeys,
               onChange: (keys: string[], rows: RowData[]) => {
-                if (selectedOption?.indexOf('overPage') !== -1) {
+                if (selectedClear?.indexOf('overPage') !== -1) {
                   setSelectedRowKeys(
                     selectedRowKeys
                       .filter(


### PR DESCRIPTION
1.此前，indexView中reload的功能依赖于onloadData函数，即overPageSelect属性=true时，reload功能会保留选中数据；反之为false时，会清除选中数据。因此新增keepReloadSelect属性，能在所有场景下使用reload时清空数据。
2.onloadData函数新增了mode可选参数，用于分辨该函数是否在reload场景执行。

新的提交：
<IndexView 
     selectedClear={['overPage', 'keepSelected']}
 />
keepSelected控制reload刷新场景下是否清空数据，overPage功能维持翻页不清空数据

feat:selectedOption -> selectedClear