### PR TITLE
Feature/[IndexView]优化下拉框placeholder属性显示，批量数据选中和禁用状态处理

### DIFF
--- a/packages/meta-components/src/components/filter-builder/components/FilterValueInput.tsx
+++ b/packages/meta-components/src/components/filter-builder/components/FilterValueInput.tsx
@@ -395,7 +395,9 @@ export const FilterValueInput: FC<FilterValueInputProps> = ({
       case MetaValueType.OBJECT_ID:
         return fieldMeta.parentKey && fieldMetaService?.findDataTrees ? (
           <FieldTreeSelect
-            placeholder={get(localeData.lang, 'filed.placeholderOp.value')}
+            placeholder={`${get(localeData.lang, 'filed.placeholderOp.value')}${
+              fieldMeta.name || ''
+            }`}
             field={fieldMeta}
             style={style}
             multiple={multiple}
@@ -406,7 +408,9 @@ export const FilterValueInput: FC<FilterValueInputProps> = ({
           />
         ) : (
           <FieldSelect
-            placeholder={get(localeData.lang, 'filed.placeholderOp.value')}
+            placeholder={`${get(localeData.lang, 'filed.placeholderOp.value')}${
+              fieldMeta.name || ''
+            }`}
             style={style}
             field={fieldMeta}
             selectMode={multiple ? 'multiple' : undefined}

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -400,7 +400,7 @@ const makeData = (current) => {
     id: `${current}-${row.id}`,
     name: `${current}-${row.name}`,
     disable: true,
-    select: true,
+    selected: true,
   }))
 }
 
@@ -492,7 +492,7 @@ export default () => {
       logicFilter
       selectedClear={['overPage']}
       defaultSelectedKeys={['1-1237', '1-1238']}
-      // rowKeys={{disabled:true,selected:true,disabledAlias:'disable',selectedAlias:'select'}}
+      // rowKeys={{disabled:'disable',selected:true}}
     >
       <ToolBar>
         <FilterPanel />

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -399,6 +399,7 @@ const makeData = (current) => {
     ...row,
     id: `${current}-${row.id}`,
     name: `${current}-${row.name}`,
+    disabled: true,
   }))
 }
 

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -399,7 +399,8 @@ const makeData = (current) => {
     ...row,
     id: `${current}-${row.id}`,
     name: `${current}-${row.name}`,
-    disabled: true,
+    disable: true,
+    select: true,
   }))
 }
 
@@ -490,12 +491,8 @@ export default () => {
       tableOperate={tableOperate}
       logicFilter
       selectedClear={['overPage']}
-      selectedKeys={{
-        default: ['1-1237', '1-1238'],
-        disabled: ['1-1234', '1-1235'],
-      }}
-      // keepReloadSelect
-      // urlQuery
+      defaultSelectedKeys={['1-1237', '1-1238']}
+      // rowKeys={{disabled:true,selected:true,disabledAlias:'disable',selectedAlias:'select'}}
     >
       <ToolBar>
         <FilterPanel />

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -917,20 +917,21 @@ export default () => {
       key: 'key-1',
       type: 'singleOption',
       name: '单选',
-      options: [
-        {
-          label: '选项1',
-          value: 'opt-1',
-        },
-        {
-          label: '选项2',
-          value: 'opt-2',
-        },
-        {
-          label: '选项3',
-          value: 'opt-3',
-        },
-      ],
+      type: 'refId',
+      // options: [
+      //   {
+      //     label: '选项1',
+      //     value: 'opt-1',
+      //   },
+      //   {
+      //     label: '选项2',
+      //     value: 'opt-2',
+      //   },
+      //   {
+      //     label: '选项3',
+      //     value: 'opt-3',
+      //   },
+      // ],
     },
     {
       key: 'key-2',

--- a/packages/meta-components/src/components/index-view/index.md
+++ b/packages/meta-components/src/components/index-view/index.md
@@ -437,10 +437,17 @@ export default () => {
       text: '打印选择行',
       type: 'danger',
       disabled: (interView) => (interView.selectedRowKeys || []).length === 0,
-      callback: (interView) =>
+      callback: (interView) => {
         message.success(
           `${(interView.selectedRowKeys || []).length} 条记录被选中了`
-        ),
+        )
+        ref.current.injectSelectedKeys(['1-1236'])
+        console.log(
+          '选中记录',
+          ref.current.selectedRowKeys,
+          ref.current.selectedRows
+        )
+      },
     },
   ]
 
@@ -467,6 +474,9 @@ export default () => {
       },
     ],
   }
+  const selectedKeys = {
+    default: ['1-1237', '1-1238'],
+  }
 
   return (
     <IndexView
@@ -478,7 +488,11 @@ export default () => {
       defaultSelectionType="checkbox"
       tableOperate={tableOperate}
       logicFilter
-      selectedClear={['overPage', 'keepSelected']}
+      selectedClear={['overPage']}
+      selectedKeys={{
+        default: ['1-1237', '1-1238'],
+        disabled: ['1-1234', '1-1235'],
+      }}
       // keepReloadSelect
       // urlQuery
     >

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -61,10 +61,8 @@ type TableOption = Pick<
 >
 
 interface RowKeysType {
-  disabled?: boolean
-  selected?: boolean
-  disabledAlias?: string
-  selectedAlias?: string
+  disabled?: string | boolean
+  selected?: string | boolean
 }
 
 export interface IIndexViewProps<IParams = any> {
@@ -155,7 +153,6 @@ export const IndexView = React.forwardRef(
   ) => {
     IndexView.defaultProps = {
       selectedClear: [],
-      // rowKeys: [{ type: 'selected', alias: 'select' }, { type: 'disabled', alias: 'disabled' }]
     }
     const [query, setQuery] = useQuery()
     const preParamsRef = useRef<Toybox.MetaSchema.Types.ICompareOperation[]>()
@@ -262,7 +259,11 @@ export const IndexView = React.forwardRef(
             data &&
             data.list
               .filter((col) => {
-                return col[rowKeys?.selectedAlias || 'selected']
+                return col[
+                  typeof rowKeys?.selected === 'boolean'
+                    ? 'selected'
+                    : rowKeys?.selected
+                ]
               })
               .map((col) => col.id)
           setSelectedRowKeys(defaultSelectedKeys)
@@ -404,7 +405,11 @@ export const IndexView = React.forwardRef(
               getCheckboxProps: (record: RowData) => ({
                 disabled:
                   rowKeys?.disabled &&
-                  record[rowKeys?.disabledAlias || 'disabled'],
+                  record[
+                    typeof rowKeys?.disabled === 'boolean'
+                      ? 'disabled'
+                      : rowKeys?.disabled
+                  ],
               }),
             }
           : undefined,

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -386,9 +386,7 @@ export const IndexView = React.forwardRef(
               },
               // TODO:禁用所在行选择框功能
               getCheckboxProps: (record: RowData) => ({
-                disabled:
-                  selectedKeys?.disabled &&
-                  selectedKeys.disabled.includes(record.id),
+                disabled: record.disabled,
               }),
             }
           : undefined,

--- a/packages/meta-components/src/components/index-view/index.tsx
+++ b/packages/meta-components/src/components/index-view/index.tsx
@@ -108,6 +108,10 @@ export interface IIndexViewProps<IParams = any> {
    */
   overPageSelect?: boolean
   selectedClear?: ('overPage' | 'keepSelected')[]
+  /**
+   * @description 控制行元素：'default'显示默认指定行,'disabled'为禁用指定行
+   */
+  selectedKeys?: { default?: string[]; disabled?: string[] }
 }
 
 export declare type IndexViewRefType = {
@@ -140,6 +144,7 @@ export const IndexView = React.forwardRef(
       overPageSelect,
       selectedClear,
       children,
+      selectedKeys,
     }: IIndexViewProps & { children: React.ReactNode },
     ref: React.MutableRefObject<IndexViewRefType>
   ) => {
@@ -191,8 +196,9 @@ export const IndexView = React.forwardRef(
         setParams(query.params ? JSON.parse(query.params) : undefined)
       }
     }, [query])
-
-    const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>([])
+    const [selectedRowKeys, setSelectedRowKeys] = useState<string[]>(
+      selectedKeys?.default || []
+    )
     const [selectedRows, setSelectedRows] = useState<RowData[]>([])
     const [selectionType, setSelectionType] = useState(defaultSelectionType)
     const [currentMode, setCurrentMode] = useState<IndexModeType>(mode)
@@ -378,6 +384,12 @@ export const IndexView = React.forwardRef(
                   setSelectedRows(rows)
                 }
               },
+              // TODO:禁用所在行选择框功能
+              getCheckboxProps: (record: RowData) => ({
+                disabled:
+                  selectedKeys?.disabled &&
+                  selectedKeys.disabled.includes(record.id),
+              }),
             }
           : undefined,
       [


### PR DESCRIPTION
1.优化远程获取数据的下拉框，placeholder属性‘请输入xxx’能够正常显示。
2.IndexView的defaultSelectedKeys属性用于预设默认选中行，其类型：string[]
3.IndexView的rowKeys属性是对于表单数据中，单条数据的选中和禁用状态处理。
   其类型：
interface RowKeysType {
  disabled?: boolean | string
  selected?: boolean | string
}